### PR TITLE
Default URL changes

### DIFF
--- a/stronghold/conf.py
+++ b/stronghold/conf.py
@@ -1,8 +1,15 @@
 from django.conf import settings
+from django.core.urlresolvers import reverse
 
 if settings.DEBUG:
     # In Debug mode we serve the media urls as public by default
-    STRONGHOLD_PUBLIC_URLS = (r'^/static/.+$', r'^/media/.+$')
+    # We should also serve the login/logout pages as public
+    STRONGHOLD_PUBLIC_URLS = (
+        r'^%s.+$' % settings.STATIC_URL,
+        r'^%s.+$' % settings.MEDIA_URL,
+        r'^%s$' % reverse('login'),
+        r'^%s$' % reverse('logout')
+        )
 else:
     # make no such assumptions in production
     STRONGHOLD_PUBLIC_URLS = ()


### PR DESCRIPTION
added login/logout views to default allowed views
made the default URLs comply with DRY
