### PR TITLE
stronghold breaks projects which don't have a `login` route defined.

### DIFF
--- a/stronghold/conf.py
+++ b/stronghold/conf.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse
 
 
 if settings.DEBUG:
@@ -8,8 +7,8 @@ if settings.DEBUG:
     STRONGHOLD_PUBLIC_URLS = (
         r'^%s.+$' % settings.STATIC_URL,
         r'^%s.+$' % settings.MEDIA_URL,
-        r'^%s$' % reverse('login'),
-        r'^%s$' % reverse('logout')
+        r'^%s$' % settings.LOGIN_URL,
+        r'^%s$' % settings.LOGOUT_URL,
     )
 else:
     # make no such assumptions in production


### PR DESCRIPTION
If you want indirection, Django 1.5 now allows you to pass named URLs and/or view function names instead. Otherwise, I'd get an error where I don't have a reverseable `login` URL.

With the way the code is structured in conf.py, this was unavoidable. Using Django's built-in mechanism for handling this should do exactly what you want, however. :smile:

``````
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/wsgiref/handlers.py", line 85, in run
    self.result = application(self.environ, self.start_response)
  File "/Users/justinlilly/.virtualenvs/glider/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 67, in __call__
    return self.application(environ, start_response)
  File "/Users/justinlilly/.virtualenvs/glider/lib/python2.7/site-packages/newrelic-1.10.2.38/newrelic/api/web_transaction.py", line 780, in __call__
    result = application(environ, _start_response)
  File "/Users/justinlilly/.virtualenvs/glider/lib/python2.7/site-packages/newrelic-1.10.2.38/newrelic/api/object_wrapper.py", line 220, in __call__
    self._nr_instance, args, kwargs)
  File "/Users/justinlilly/.virtualenvs/glider/lib/python2.7/site-packages/newrelic-1.10.2.38/newrelic/api/function_trace.py", line 88, in literal_wrapper
    return wrapped(*args, **kwargs)
  File "/Users/justinlilly/.virtualenvs/glider/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 219, in __call__
    self.load_middleware()
  File "/Users/justinlilly/.virtualenvs/glider/lib/python2.7/site-packages/django/core/handlers/base.py", line 45, in load_middleware
    mod = import_module(mw_module)
  File "/Users/justinlilly/.virtualenvs/glider/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/Users/justinlilly/.virtualenvs/glider/src/stronghold/stronghold/middleware.py", line 4, in <module>
    from stronghold import conf
  File "/Users/justinlilly/.virtualenvs/glider/src/stronghold/stronghold/conf.py", line 11, in <module>
    r'^%s$' % reverse('login'),
  File "/Users/justinlilly/.virtualenvs/glider/lib/python2.7/site-packages/django/core/urlresolvers.py", line 476, in reverse
    return iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs))
  File "/Users/justinlilly/.virtualenvs/glider/lib/python2.7/site-packages/django/core/urlresolvers.py", line 396, in _reverse_with_prefix
    "arguments '%s' not found." % (lookup_view_s, args, kwargs))
NoReverseMatch: Reverse for 'login' with arguments '()' and keyword arguments '{}' not found.```
``````
