### PR TITLE
Support for non-blank server root URLs

### DIFF
--- a/stronghold/middleware.py
+++ b/stronghold/middleware.py
@@ -27,7 +27,7 @@ class LoginRequiredMiddleware(object):
 
         # if this view matches a whitelisted regex, don't process it
         for view_url in self.public_view_urls:
-            if view_url.match(request.path):
+            if view_url.match(request.path_info):
                 return None
 
         return login_required(view_func)(request, *view_args, **view_kwargs)


### PR DESCRIPTION
Using request.path_info instead of request.path for regex matching.
This opens support for root server URLs in the form of
'www.example.com/django_root/view_url' as opposed to 
just 'www.example.com/view_url'

More info about path vs path_info here:
https://docs.djangoproject.com/en/dev/ref/request-response/#attributes
