### PR TITLE
add media url to fix test_project issue

### DIFF
--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -27,7 +27,7 @@ USE_L10N = True
 USE_TZ = True
 
 MEDIA_ROOT = ''
-MEDIA_URL = ''
+MEDIA_URL = '/media/'
 
 STATIC_ROOT = ''
 STATIC_URL = '/static/'


### PR DESCRIPTION
When the media_url is not set then one of the default stronghold public urls matches every pattern. The test project doesn't set this and so it doesn't function properly. This fixes that.

In short: MEDIA_URL is required to be set for the stronghold middleware to be useful.
