### PR TITLE
add python requirements for running tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Django==1.5
+mock==1.0.1
+wsgiref==0.1.2


### PR DESCRIPTION
This will make it easier for people to contribute.

The requirements can be installed by issuing the following command at the
root of the project:

```
$ pip install -r requirements.txt
```

In the event that you do not have pip you can obtain it via easy_install:

```
$ easy_install pip
```

Or apt-get:

```
$ apt-get install python-pip
```
