### PR TITLE
Refactor public_view_url check to be more pythonic

### DIFF
--- a/stronghold/middleware.py
+++ b/stronghold/middleware.py
@@ -11,7 +11,9 @@ class LoginRequiredMiddleware(object):
     View is also deemed to be Public if listed in in django settings in the
     STRONGHOLD_PUBLIC_URLS dictionary
     each url in STRONGHOLD_PUBLIC_URLS must be a valid regex
+
     """
+
     def __init__(self, *args, **kwargs):
         self.public_view_urls = getattr(conf, 'STRONGHOLD_PUBLIC_URLS', ())
 
@@ -21,13 +23,11 @@ class LoginRequiredMiddleware(object):
             return None
 
         # if its a public view, don't process it
-        is_public = utils.is_view_func_public(view_func)
-        if is_public:
+        if utils.is_view_func_public(view_func):
             return None
 
         # if this view matches a whitelisted regex, don't process it
-        for view_url in self.public_view_urls:
-            if view_url.match(request.path_info):
-                return None
+        if any(view_url.match(request.path_info) for view_url in self.public_view_urls):
+            return None
 
         return login_required(view_func)(request, *view_args, **view_kwargs)


### PR DESCRIPTION
In addition to this I also removed the is_public variable because the new utils
function says the same thing so it is redundant.
