### PR TITLE
add only_staff and only_superuser options to stronghold

### DIFF
--- a/stronghold/conf.py
+++ b/stronghold/conf.py
@@ -7,6 +7,8 @@ from django.conf import settings
 STRONGHOLD_PUBLIC_URLS = getattr(settings, 'STRONGHOLD_PUBLIC_URLS', ())
 STRONGHOLD_DEFAULTS = getattr(settings, 'STRONGHOLD_DEFAULTS', True)
 STRONGHOLD_PUBLIC_NAMED_URLS = getattr(settings, 'STRONGHOLD_PUBLIC_NAMED_URLS', ())
+STRONGHOLD_ONLY_STAFF = getattr(settings, 'STRONGHOLD_ONLY_STAFF', ())
+STRONGHOLD_ONLY_SUPERUSER = getattr(settings, 'STRONGHOLD_ONLY_SUPERUSER', ())
 
 if STRONGHOLD_DEFAULTS:
     if 'django.contrib.auth' in settings.INSTALLED_APPS:

--- a/stronghold/middleware.py
+++ b/stronghold/middleware.py
@@ -1,4 +1,5 @@
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth import logout as auth_logout
 from stronghold import conf, utils
 
 
@@ -16,10 +17,17 @@ class LoginRequiredMiddleware(object):
 
     def __init__(self, *args, **kwargs):
         self.public_view_urls = getattr(conf, 'STRONGHOLD_PUBLIC_URLS', ())
+        self.only_superuser = getattr(conf, 'STRONGHOLD_ONLY_SUPERUSER', False)
+        self.only_staff = getattr(conf, 'STRONGHOLD_ONLY_STAFF', False)
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        if request.user.is_authenticated() or utils.is_view_func_public(view_func) \
-                or self.is_public_url(request.path_info):
+        if request.user.is_authenticated():
+            if (self.only_superuser and not request.user.is_superuser) or (self.only_staff and not (request.user.is_staff or request.user.is_superuser)):
+                auth_logout(request)
+                return user_passes_test(lambda u: False)(lambda r: None)(request)
+            return None
+
+        if utils.is_view_func_public(view_func) or self.is_public_url(request.path_info):
             return None
 
         return login_required(view_func)(request, *view_args, **view_kwargs)


### PR DESCRIPTION
Restrict the site further to only staff or only superusers.

This can be useful when normal users should not have access to the website.
