### PR TITLE
Fix tests to work with Django 1.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - DJANGO_VERSION=1.5.5
   - DJANGO_VERSION=1.6.1
 install:
+  - pip install -r requirements.txt
   - pip install Django==$DJANGO_VERSION
   - python setup.py install
 script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test:
-	python test_project/manage.py test stronghold
+	python test_project/manage.py test --settings=test_project.settings stronghold.tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-Django==1.4.3
 Jinja2==2.6
 Pygments==1.6
 Sphinx==1.1.3
 docutils==0.10
 mock==1.0.1
+django-discover-runner==1.0
+

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -110,3 +110,9 @@ LOGGING = {
         },
     }
 }
+
+
+import django
+
+if django.VERSION[:2] < (1, 6):
+    TEST_RUNNER = 'discover_runner.DiscoverRunner'


### PR DESCRIPTION
Use django-discover-runner to run tests in the case of Django version <
1.6 . Still a little hackish, but viable way to get the tests run for
now.

Update .travis yml to install new requirements before a test run,
update makefile to run tests using discover runner and explicitly use
the settings we have setup in the test project
