### PR TITLE
Configurable Permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
   - DJANGO_VERSION=1.4.13
   - DJANGO_VERSION=1.5.8
   - DJANGO_VERSION=1.6.5
-  - DJANGO_VERSION=1.7b4
 install:
   - pip install -r requirements.txt
   - pip install Django==$DJANGO_VERSION

--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ STRONGHOLD_PUBLIC_NAMED_URLS = ()
 If STRONGHOLD_DEFAULTS is True additionally we search for `django.contrib.auth`
 if it exists, we add the login and logout view names to `STRONGHOLD_PUBLIC_NAMED_URLS`
 
+###STRONGHOLD_PERMISSIONS_DECORATOR
+Optionally configure STRONGHOLD_PERMISSIONS_DECORATOR to be something besides
+`login_required`. This allows the developer to set this to an alternative
+decorator like `staff_member_required` or a user created decorator that
+processes a view function and returns `None` or a `HTTPResponse`.
+
+**Default**:
+```python
+STRONGHOLD_PERMISSIONS_DECORATOR = login_required
+```
+
 ##Compatiblity
 
 Tested with:

--- a/README.rst
+++ b/README.rst
@@ -143,13 +143,27 @@ If STRONGHOLD\_DEFAULTS is True additionally we search for
 ``django.contrib.auth`` if it exists, we add the login and logout view
 names to ``STRONGHOLD_PUBLIC_NAMED_URLS``
 
+STRONGHOLD\_PERMISSIONS\_DECORATOR
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Optionally configure STRONGHOLD_PERMISSIONS_DECORATOR to be something besides
+``login_required``. This allows the developer to set this to an alternative
+decorator like ``staff_member_required`` or a user created decorator that
+processes a view function and returns ``None`` or a ``HTTPResponse``.
+
+**Default**:
+
+.. code:: python
+    STRONGHOLD_PERMISSIONS_DECORATOR = login_required
+
+
 Compatiblity
 ------------
 
-Tested with: 
+Tested with:
 
-- Django 1.4.x 
-- Django 1.5.x 
+- Django 1.4.x
+- Django 1.5.x
 - Django 1.6.x
 
 Contribute

--- a/stronghold/conf.py
+++ b/stronghold/conf.py
@@ -2,11 +2,14 @@ import re
 
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 
 
 STRONGHOLD_PUBLIC_URLS = getattr(settings, 'STRONGHOLD_PUBLIC_URLS', ())
 STRONGHOLD_DEFAULTS = getattr(settings, 'STRONGHOLD_DEFAULTS', True)
 STRONGHOLD_PUBLIC_NAMED_URLS = getattr(settings, 'STRONGHOLD_PUBLIC_NAMED_URLS', ())
+STRONGHOLD_PERMISSIONS_DECORATOR = getattr(settings, 'STRONGHOLD_PERMISSIONS_DECORATOR', login_required)
+
 
 if STRONGHOLD_DEFAULTS:
     if 'django.contrib.auth' in settings.INSTALLED_APPS:

--- a/stronghold/middleware.py
+++ b/stronghold/middleware.py
@@ -1,10 +1,11 @@
-from django.contrib.auth.decorators import login_required
 from stronghold import conf, utils
 
 
 class LoginRequiredMiddleware(object):
     """
-    Force all views to use login required
+    Force all views to use the permissions defined by
+    STRONGHOLD_PERMISSIONS_DECORATOR. Default is login_required, but can use
+    staff_member_required or a user defined decorator
 
     View is deemed to be public if the @public decorator is applied to the view
 
@@ -22,7 +23,7 @@ class LoginRequiredMiddleware(object):
                 or self.is_public_url(request.path_info):
             return None
 
-        return login_required(view_func)(request, *view_args, **view_kwargs)
+        return conf.STRONGHOLD_PERMISSIONS_DECORATOR(view_func)(request, *view_args, **view_kwargs)
 
     def is_public_url(self, url):
         return any(public_url.match(url) for public_url in self.public_view_urls)


### PR DESCRIPTION
This adds the setting `STRONGHOLD_PERMISSIONS_DECORATOR`.
`STRONGHOLD_PERMISSIONS_DECORATOR` allows the developer to define the
decorator to use to define the behavior of Stronghold. The current
behavior defaults to the login_required decorator. You could change this
setting to staff_member_required and it would apply this to all non
whitelisted or views marked public.

Developers can also write their own decorator that requires any
combination of permissions they desire here.

Fixes #34 Thanks @andybak for the idea.
