### PR TITLE
Add CBV mixin to be used alongside the method decorator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ def someview(request):
 
 ```
 
-###for class based views
+###for class based views (decorator)
 
 ```python
 from django.utils.decorators import method_decorator
@@ -68,6 +68,16 @@ class SomeView(View):
 	@method_decorator(public)
 	def dispatch(self, *args, **kwargs):
     	return super(SomeView, self).dispatch(*args, **kwargs)
+```
+
+###for class based views (mixin)
+
+```python
+from stronghold.views import StrongholdPublicMixin
+
+
+class SomeView(StrongholdPublicMixin, View):
+	pass
 ```
 
 ##Configuration (optional)

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,8 @@ For function based views
         # do some work
         #...
 
-for class based views
-~~~~~~~~~~~~~~~~~~~~~
+for class based views (decorator)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
@@ -79,6 +79,16 @@ for class based views
         @method_decorator(public)
         def dispatch(self, *args, **kwargs):
             return super(SomeView, self).dispatch(*args, **kwargs)
+
+for class based views (mixin)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+    from stronghold import StrongholdPublicMixin
+
+    class SomeView(StrongholdPublicMixin, View):
+        pass
 
 Configuration (optional)
 ------------------------

--- a/stronghold/tests/__init__.py
+++ b/stronghold/tests/__init__.py
@@ -1,3 +1,4 @@
 from stronghold.tests.testdecorators import *
 from stronghold.tests.testmiddleware import *
+from stronghold.tests.testmixins import *
 from stronghold.tests.testutils import *

--- a/stronghold/tests/testmixins.py
+++ b/stronghold/tests/testmixins.py
@@ -1,0 +1,22 @@
+from stronghold.views import StrongholdPublicMixin
+
+from django.utils import unittest
+from django.views.generic import View
+from django.views.generic.base import TemplateResponseMixin
+
+
+class StrongholdMixinsTests(unittest.TestCase):
+
+    def test_public_mixin_sets_attr(self):
+
+        class TestView(StrongholdPublicMixin, View):
+            pass
+
+        self.assertTrue(TestView.dispatch.STRONGHOLD_IS_PUBLIC)
+
+    def test_public_mixin_sets_attr_with_multiple_mixins(self):
+
+        class TestView(StrongholdPublicMixin, TemplateResponseMixin, View):
+            template_name = 'dummy.html'
+
+        self.assertTrue(TestView.dispatch.STRONGHOLD_IS_PUBLIC)

--- a/stronghold/views.py
+++ b/stronghold/views.py
@@ -1,0 +1,9 @@
+from django.utils.decorators import method_decorator
+from stronghold.decorators import public
+
+
+class StrongholdPublicMixin(object):
+
+    @method_decorator(public)
+    def dispatch(self, *args, **kwargs):
+        return super(StrongholdPublicMixin, self).dispatch(*args, **kwargs)


### PR DESCRIPTION
Using a mixin provides a smoother way to exempt class based views from
stronghold.