### PR TITLE
Django 1.8, 1.9 and Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,32 @@ python:
   - "2.6"
   - "2.7"
   - "3.4"
+  - "3.5"
 env:
   - DJANGO_VERSION=1.4.13
   - DJANGO_VERSION=1.5.8
   - DJANGO_VERSION=1.6.5
   - DJANGO_VERSION=1.7.1
+  - DJANGO_VERSION=1.8.8
+  - DJANGO_VERSION=1.9.1
 matrix:
   exclude:
     - python: "2.6"
       env: DJANGO_VERSION=1.7.1
+    - python: "2.6"
+      env: DJANGO_VERSION=1.8.8
+    - python: "2.6"
+      env: DJANGO_VERSION=1.9.1
     - python: "3.4"
       env: DJANGO_VERSION=1.4.13
+    - python: "3.5"
+      env: DJANGO_VERSION=1.4.13
+    - python: "3.5"
+      env: DJANGO_VERSION=1.5.8
+    - python: "3.5"
+      env: DJANGO_VERSION=1.6.5
+    - python: "3.5"
+      env: DJANGO_VERSION=1.7.1
 install:
   - pip install -r requirements.txt
   - pip install Django==$DJANGO_VERSION

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Tested with:
 * Django 1.5.x
 * Django 1.6.x
 * Django 1.7.x
+* Django 1.8.x
+* Django 1.9.x
 
 ##Contribute
 

--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,8 @@ Tested with:
 - Django 1.5.x
 - Django 1.6.x
 - Django 1.7.x
+- Django 1.8.x
+- Django 1.9.x
 
 Contribute
 ----------

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ),
 )

--- a/stronghold/tests/testdecorators.py
+++ b/stronghold/tests/testdecorators.py
@@ -2,7 +2,11 @@ import functools
 
 from stronghold import decorators
 
-from django.utils import unittest
+import django
+if django.VERSION[:2] < (1, 9):
+    from django.utils import unittest
+else:
+    import unittest
 
 
 class StrongholdDecoratorTests(unittest.TestCase):

--- a/stronghold/tests/testmixins.py
+++ b/stronghold/tests/testmixins.py
@@ -1,8 +1,13 @@
 from stronghold.views import StrongholdPublicMixin
 
-from django.utils import unittest
+import django
 from django.views.generic import View
 from django.views.generic.base import TemplateResponseMixin
+
+if django.VERSION[:2] < (1, 9):
+    from django.utils import unittest
+else:
+    import unittest
 
 
 class StrongholdMixinsTests(unittest.TestCase):

--- a/stronghold/tests/testutils.py
+++ b/stronghold/tests/testutils.py
@@ -1,6 +1,10 @@
 from stronghold import utils
 
-from django.utils import unittest
+import django
+if django.VERSION[:2] < (1, 9):
+    from django.utils import unittest
+else:
+    import unittest
 
 
 class IsViewFuncPublicTests(unittest.TestCase):


### PR DESCRIPTION
Add support for Django 1.9, Django 1.8 and Python 3.5.

- Update READMEs for advertising new Django version
- Update setup.py for advertising new Python version
- Update tests to work on Django 1.9 in the lack of django.utils.unittest.
- Update Travis test matrix to exclude incompatible versions of Django and Python.