### PR TITLE
Fix Travis Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![travis](https://travis-ci.org/mgrouchy/django-stronghold.png?branch=master)
+[![Build Status](https://travis-ci.org/mgrouchy/django-stronghold.svg?branch=master)](https://travis-ci.org/mgrouchy/django-stronghold)
 
 #Stronghold
 


### PR DESCRIPTION
The Travis build badge was previously linking to the image instead of the build page. I found the build page and copy-pasted the markdown for displaying the badge properly.