### PR TITLE
Update tests for Django 1.10

### DIFF
--- a/stronghold/tests/testmiddleware.py
+++ b/stronghold/tests/testmiddleware.py
@@ -36,22 +36,31 @@ class LoginRequiredMiddlewareTests(TestCase):
             'request': self.request,
         }
 
+    def set_authenticated(self, is_authenticated):
+        """Set whether user is authenticated in the request."""
+        user = self.request.user
+        user.is_authenticated.return_value = is_authenticated
+
+        # In Django >= 1.10, is_authenticated acts as property and method
+        user.is_authenticated.__bool__ = lambda self: is_authenticated
+        user.is_authenticated.__nonzero__ = lambda self: is_authenticated
+
     def test_redirects_to_login_when_not_authenticated(self):
-        self.request.user.is_authenticated.return_value = False
+        self.set_authenticated(False)
 
         response = self.middleware.process_view(**self.kwargs)
 
         self.assertEqual(response.status_code, 302)
 
     def test_returns_none_when_authenticated(self):
-        self.request.user.is_authenticated.return_value = True
+        self.set_authenticated(True)
 
         response = self.middleware.process_view(**self.kwargs)
 
         self.assertEqual(response, None)
 
     def test_returns_none_when_url_is_in_public_urls(self):
-        self.request.user.is_authenticated.return_value = False
+        self.set_authenticated(False)
         self.middleware.public_view_urls = [re.compile(r'/test-protected-url/')]
 
         response = self.middleware.process_view(**self.kwargs)
@@ -59,7 +68,7 @@ class LoginRequiredMiddlewareTests(TestCase):
         self.assertEqual(response, None)
 
     def test_returns_none_when_url_is_decorated_public(self):
-        self.request.user.is_authenticated.return_value = False
+        self.set_authenticated(False)
 
         self.kwargs['view_func'].STRONGHOLD_IS_PUBLIC = True
         response = self.middleware.process_view(**self.kwargs)


### PR DESCRIPTION
In Django 1.10, the user.is_authenticated can act as a method or a
property.  Django depricated its use as a method and will be removed in
Django 2.0.  Django has internally changed its code to use it as a
property.  This patch updates the mock setup of is_authenticated to work
like a property or a method.