### PR TITLE
Drop python 2.6 tests for Django >= 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - python: "2.6"
       env: DJANGO_VERSION=1.8.18
     - python: "2.6"
-      env: DJANGO_VERSION=1.9.1
+      env: DJANGO_VERSION=1.9.13
     - python: "2.6"
       env: DJANGO_VERSION=1.10.7
     - python: "2.6"


### PR DESCRIPTION
A typo in the tests exclude is letting travis' matrix run python 2.6 tests on Django 1.9.13. This fixes the typo and, with some luck, CI on master.