### PR TITLE
Github Markdown Changes - Formatting Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ STRONGHOLD_USER_TEST_FUNC = lambda user: user.is_staff
 STRONGHOLD_USER_TEST_FUNC = lambda user: user.is_authenticated()
 ```
 
-##Compatiblity
+## Compatiblity
 
 Tested with:
 * Django 1.4.x


### PR DESCRIPTION
Github's markdown processor changed. Most of the readme was fixed but this header still needs to be pretty too.