### PR TITLE
Update middleware.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ test_dependencies = ['django>1.4.0']
 
 setup(
     name='django-stronghold',
-    version='0.2.9',
+    version='0.2.9.1',
     description='Get inside your stronghold and make all your Django views default login_required',
     url='https://github.com/mgrouchy/django-stronghold',
     author='Mike Grouchy',

--- a/stronghold/middleware.py
+++ b/stronghold/middleware.py
@@ -26,9 +26,9 @@ class LoginRequiredMiddleware(MiddlewareMixin):
         self.public_view_urls = getattr(conf, 'STRONGHOLD_PUBLIC_URLS', ())
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        if conf.STRONGHOLD_USER_TEST_FUNC(request.user) \
-                or utils.is_view_func_public(view_func) \
-                or self.is_public_url(request.path_info):
+        if utils.is_view_func_public(view_func) \
+                or self.is_public_url(request.path_info) \
+                or conf.STRONGHOLD_USER_TEST_FUNC(request.user):
             return None
 
         decorator = user_passes_test(conf.STRONGHOLD_USER_TEST_FUNC)


### PR DESCRIPTION
Change order of conditions so that public views are boolean short-circuited without evaluating the user test func.  This is useful in case the user test func raises an exception like PermissionDenied.