### PR TITLE
Fix for Django 2.1 decorators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,16 @@ env:
   - DJANGO_VERSION="django>=1.10,<1.11"
   - DJANGO_VERSION="django>=1.11,<1.12"
   - DJANGO_VERSION="django>=2.0,<2.1"
+  - DJANGO_VERSION="django>=2.1,<2.2"
+  - DJANGO_VERSION="django>=2.2,<2.3"
 matrix:
   exclude:
     - python: "2.7"
       env: DJANGO_VERSION="django>=2.0,<2.1"
+    - python: "2.7"
+      env: DJANGO_VERSION="django>=2.1,<2.2"
+    - python: "2.7"
+      env: DJANGO_VERSION="django>=2.2,<2.3"
 install:
   - pip install -r requirements.txt
   - pip install $DJANGO_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 python:
   - "2.7"
   - "3.4"
@@ -19,6 +20,10 @@ matrix:
     - python: "2.7"
       env: DJANGO_VERSION="django>=2.1,<2.2"
     - python: "2.7"
+      env: DJANGO_VERSION="django>=2.2,<2.3"
+    - python: "3.4"
+      env: DJANGO_VERSION="django>=2.1,<2.2"
+    - python: "3.4"
       env: DJANGO_VERSION="django>=2.2,<2.3"
 install:
   - pip install -r requirements.txt

--- a/stronghold/decorators.py
+++ b/stronghold/decorators.py
@@ -10,6 +10,13 @@ def public(function):
     orig_func = function
     while isinstance(orig_func, partial):
         orig_func = orig_func.func
+    if hasattr(orig_func, "__self__"):
+        def bound_method(*args, **kwargs):
+            return orig_func.__get__(orig_func.__self__, type(orig_func.__self__))(*args, **kwargs)
+        
+        set_view_func_public(bound_method)
+        return bound_method
+
     set_view_func_public(orig_func)
 
     return function

--- a/stronghold/decorators.py
+++ b/stronghold/decorators.py
@@ -8,15 +8,17 @@ def public(function):
     Sets an attribute in the fuction STRONGHOLD_IS_PUBLIC to True
     """
     orig_func = function
+    outer_partial_wrapper = None
     while isinstance(orig_func, partial):
+        outer_partial_wrapper = orig_func
         orig_func = orig_func.func
-    if hasattr(orig_func, "__self__"):
-        def bound_method(*args, **kwargs):
-            return orig_func.__get__(orig_func.__self__, type(orig_func.__self__))(*args, **kwargs)
-        
-        set_view_func_public(bound_method)
-        return bound_method
-
+    # For Django >= 2.1.x:
+    # If `function` is a bound method, django will wrap it in a partial
+    # to allow setting attributes on a bound method.
+    # Bound methods have the attr "__self__". If this is the case,
+    # we reapply the partial wrapper before setting the attribute.
+    if hasattr(orig_func, "__self__") and outer_partial_wrapper != None:
+        orig_func = outer_partial_wrapper
     set_view_func_public(orig_func)
 
     return function

--- a/stronghold/tests/testdecorators.py
+++ b/stronghold/tests/testdecorators.py
@@ -46,15 +46,3 @@ class StrongholdDecoratorTests(unittest.TestCase):
                 pass
 
         self.assertTrue(TestClass.function.STRONGHOLD_IS_PUBLIC)
-
-    def test_public_method_decorator_works_with_partials(self):
-        def partial_decorator(func):
-            return functools.partial(func)
-
-        class TestClass:
-            @method_decorator(decorators.public)
-            @method_decorator(partial_decorator)
-            def function(self):
-                pass
-        
-        self.assertTrue(TestClass.function.STRONGHOLD_IS_PUBLIC)

--- a/stronghold/tests/testdecorators.py
+++ b/stronghold/tests/testdecorators.py
@@ -7,6 +7,7 @@ if django.VERSION[:2] < (1, 9):
     from django.utils import unittest
 else:
     import unittest
+from django.utils.decorators import method_decorator
 
 
 class StrongholdDecoratorTests(unittest.TestCase):
@@ -37,3 +38,23 @@ class StrongholdDecoratorTests(unittest.TestCase):
         decorators.public(partial)
 
         self.assertTrue(function.STRONGHOLD_IS_PUBLIC)
+
+    def test_public_decorator_works_with_method_decorator(self):
+        class TestClass:
+            @method_decorator(decorators.public)
+            def function(self):
+                pass
+
+        self.assertTrue(TestClass.function.STRONGHOLD_IS_PUBLIC)
+
+    def test_public_method_decorator_works_with_partials(self):
+        def partial_decorator(func):
+            return functools.partial(func)
+
+        class TestClass:
+            @method_decorator(decorators.public)
+            @method_decorator(partial_decorator)
+            def function(self):
+                pass
+        
+        self.assertTrue(TestClass.function.STRONGHOLD_IS_PUBLIC)

--- a/test_project/test_project/urls.py
+++ b/test_project/test_project/urls.py
@@ -5,4 +5,6 @@ from . import views
 urlpatterns = [
     url(r'^protected/$', views.ProtectedView.as_view(), name="protected_view"),
     url(r'^public/$', views.PublicView.as_view(), name="public_view"),
+    url(r'^public2/$', views.PublicView2.as_view(), name="public_view2"),
+    url(r'^public3/$', views.public_view3, name="public_view3")
 ]

--- a/test_project/test_project/views.py
+++ b/test_project/test_project/views.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 
 from stronghold.decorators import public
+from stronghold.views import StrongholdPublicMixin
 
 
 class ProtectedView(View):
@@ -19,3 +20,13 @@ class PublicView(View):
 
     def get(self, request, *args, **kwargs):
         return HttpResponse("PublicView")
+
+class PublicView2(StrongholdPublicMixin, View):
+    """ A view we want to be public, using the StrongholdPublicMixin"""
+    def get(self, request, *args, **kwargs):
+        return HttpResponse("PublicView")
+
+@public
+def public_view3(request):
+    """ A function view we want to be public"""
+    return HttpResponse("PublicView")


### PR DESCRIPTION
This is a semi-hacky way to make django-stronghold work on Django 2.1

Additionally, added a couple views to the test project to make it easier to test the different methods of declaring a public view.