### PR TITLE
docs: Fix simple typo, utilties -> utilities

### DIFF
--- a/docs/_build/html/_static/searchtools.js
+++ b/docs/_build/html/_static/searchtools.js
@@ -2,7 +2,7 @@
  * searchtools.js_t
  * ~~~~~~~~~~~~~~~~
  *
- * Sphinx JavaScript utilties for the full-text search.
+ * Sphinx JavaScript utilities for the full-text search.
  *
  * :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
  * :license: BSD, see LICENSE for details.

--- a/docs/_build/html/_static/websupport.js
+++ b/docs/_build/html/_static/websupport.js
@@ -2,7 +2,7 @@
  * websupport.js
  * ~~~~~~~~~~~~~
  *
- * sphinx.websupport utilties for all documentation.
+ * sphinx.websupport utilities for all documentation.
  *
  * :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
  * :license: BSD, see LICENSE for details.


### PR DESCRIPTION
There is a small typo in docs/_build/html/_static/searchtools.js, docs/_build/html/_static/websupport.js.

Should read `utilities` rather than `utilties`.

