### PR TITLE
Fix tests for Django 4.0

### DIFF
--- a/stronghold/tests/testmiddleware.py
+++ b/stronghold/tests/testmiddleware.py
@@ -28,7 +28,7 @@ class StrongholdMiddlewareTestCase(TestCase):
 class LoginRequiredMiddlewareTests(TestCase):
 
     def setUp(self):
-        self.middleware = LoginRequiredMiddleware()
+        self.middleware = LoginRequiredMiddleware(True)
 
         self.request = RequestFactory().get('/test-protected-url/')
         self.request.user = mock.Mock()

--- a/test_project/test_project/urls.py
+++ b/test_project/test_project/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import re_path
 from . import views
 
 
 urlpatterns = [
-    url(r'^protected/$', views.ProtectedView.as_view(), name="protected_view"),
-    url(r'^public/$', views.PublicView.as_view(), name="public_view"),
-    url(r'^public2/$', views.PublicView2.as_view(), name="public_view2"),
-    url(r'^public3/$', views.public_view3, name="public_view3")
+    re_path(r'^protected/$', views.ProtectedView.as_view(), name="protected_view"),
+    re_path(r'^public/$', views.PublicView.as_view(), name="public_view"),
+    re_path(r'^public2/$', views.PublicView2.as_view(), name="public_view2"),
+    re_path(r'^public3/$', views.public_view3, name="public_view3")
 ]


### PR DESCRIPTION
- Pass dummy parameter to middleware constructor
- Use re_path for urlpatterns