### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -271,7 +271,7 @@ epub_copyright = u'2013, Mike Grouchy'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/stronghold/decorators.py
+++ b/stronghold/decorators.py
@@ -5,7 +5,7 @@ from stronghold.utils import set_view_func_public
 def public(function):
     """
     Decorator for public views that do not require authentication
-    Sets an attribute in the fuction STRONGHOLD_IS_PUBLIC to True
+    Sets an attribute in the function STRONGHOLD_IS_PUBLIC to True
     """
     orig_func = function
     outer_partial_wrapper = None


### PR DESCRIPTION
There are small typos in:
- docs/conf.py
- stronghold/decorators.py

Fixes:
- Should read `that` rather than `shat`.
- Should read `function` rather than `fuction`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md